### PR TITLE
Adding a `isLoading` property to `LocalStorageProperties`

### DIFF
--- a/src/useLocalStorageState.ts
+++ b/src/useLocalStorageState.ts
@@ -11,6 +11,7 @@ const activeHooks: {
 
 type UpdateState<T> = (newValue: T | ((value: T) => T)) => void
 type LocalStorageProperties = {
+    isLoading: boolean
     isPersistent: boolean
     removeItem: () => void
 }
@@ -36,7 +37,7 @@ export default function useLocalStorageState<T = undefined>(
         return [
             options?.defaultValue,
             (): void => {},
-            { isPersistent: true, removeItem: (): void => {} },
+            { isPersistent: true, isLoading:true, removeItem: (): void => {} },
         ]
     }
 
@@ -126,6 +127,7 @@ function useClientLocalStorageState<T>(
             },
             {
                 isPersistent: ssr && isFirstRender.current ? true : !storage.data.has(key),
+                isLoading: !ssr || (ssr && id > 0),
                 removeItem(): void {
                     storage.remove(key)
 


### PR DESCRIPTION
Hello! First of, thank you for this library 🙇🏻 

I ran into an issue while using this lib. I'd need to store a value in local storage and do something with it once it is available. Let's see a quick example:

```typescript
const MyComponent = () => {
  const [data] = useLocalStorageState<string>(
    'my-data', { ssr: true }
  );

  console.info('data is...', data);

  useEffect(() => {
    // I want to do something with data here 🧐
  }, [data]);

  // [...]
}
```

When we run this, we get the following result with `my-data` set to "cool":

```bash
data is... undefined
data is... cool
```

Nothing crazy here, we get the default value, which is not set. 
Now, what if I needed to execute that side effect only when the value is actually the one set in local storage?

I propose the following solution to solve that issue: adding a `isLoading` prop to `LocalStorageProperties`.
Intended usage could look like this:

```typescript
const MyComponent = () => {
  const [data,,{ isLoading }] = useLocalStorageState<string>(
    'my-data', { ssr: true }
  );

  useEffect(() => {
    if(!isLoading) {
      // I will have the actual value now! 🎉
    }
  }, [data, isLoading]);

  // [...]
}
```

What do you think about the idea? Let me know if I missed anything!