### PR TITLE
Support superjson serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "react-dom": "^17.0.1",
         "react-test-renderer": "^17.0.1",
         "size-limit": "^7.0.5",
+        "superjson": "^1.8.1",
         "ts-jest": "^27.1.3",
         "typescript": "^4.5.4"
     },

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,14 @@ Default: `false`
 
 Enables SSR support and handles hydration mismatches. Not enabling this can cause the following error: `Warning: Expected server HTML to contain a matching ...`. This is the only library I'm aware of that handles this case. For more, see [discussion here](https://github.com/astoilkov/use-local-storage-state/issues/23).
 
+### `options.serializer`
+
+Type: `Pick<typeof JSON, 'stringify' | 'parse'>`
+
+Default: `JSON`
+
+JSON does not serialize `Date`, `Regex`, or `BigInt` data.  Can pass in [superjson](https://www.npmjs.com/package/superjson) or other `JSON`-compatible serialization classes for more advanced serialization.
+
 ## Alternatives
 
 These are the best alternatives to my repo I have found so far:

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -7,42 +7,51 @@
  * - trying to access localStorage object when cookies are disabled in Safari throws
  *   "SecurityError: The operation is insecure."
  */
-export default {
-    data: new Map<string, unknown>(),
+
+export type Serializer = Pick<typeof JSON, 'stringify' | 'parse'>
+
+class Storage {
+    public static data = new Map<string, unknown>()
+    private readonly serializer: Serializer
+    constructor(serializer: Serializer) {
+        this.serializer = serializer
+     }
     get<T>(key: string, defaultValue: T): T | undefined {
         try {
-            return this.data.has(key)
-                ? (this.data.get(key) as T | undefined)
-                : parseJSON<T>(localStorage.getItem(key))
+            return Storage.data.has(key)
+                ? (Storage.data.get(key) as T | undefined)
+                : parseJSON(localStorage.getItem(key), this.serializer.parse)
         } catch {
             return defaultValue
         }
-    },
+    }
     set<T>(key: string, value: T): void {
         try {
-            localStorage.setItem(key, JSON.stringify(value))
+            localStorage.setItem(key, this.serializer.stringify(value))
 
-            this.data.delete(key)
+            Storage.data.delete(key)
         } catch {
-            this.data.set(key, value)
+            Storage.data.set(key, value)
         }
-    },
+    }
     remove(key: string): void {
-        this.data.delete(key)
+        Storage.data.delete(key)
         localStorage.removeItem(key)
-    },
+    }
 }
 
 /**
  * A wrapper for `JSON.parse()` which supports the return value of `JSON.stringify(undefined)`
  * which returns the string `"undefined"` and this method returns the value `undefined`.
  */
-function parseJSON<T>(value: string | null): T | undefined {
+function parseJSON<T>(value: string | null, parse: typeof JSON.parse): T | undefined {
     return value === 'undefined'
         ? undefined
         : // - `JSON.parse()` TypeScript types don't accept non-string values, this is why we pass
           //   empty string which will throw an error
           // - when `value` is `null`, we will pass empty string and the `JSON.parse()` will throw
           //   an error which we need and is required by the parent function
-          JSON.parse(value ?? '')
+          parse(value ?? '')
 }
+
+export default Storage


### PR DESCRIPTION
Hi @astoilkov: thanks for this great package!  Here is a feature I'm using that I hope we can incorporate!

JSON does not serialize `Date`, `Regex`, or `BigInt` data.  This PR allows users to pass in [superjson](https://www.npmjs.com/package/superjson) or other `JSON`-compatible serialization classes for more advanced serialization.

See `README.md` and `test.tsx`