### PR TITLE
Support functional lazy initializer

### DIFF
--- a/src/useLocalStorageState.ts
+++ b/src/useLocalStorageState.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from 'react'
-import { useRef, useMemo, useEffect, useCallback, useSyncExternalStore } from 'react'
+import { useRef, useState, useMemo, useEffect, useCallback, useSyncExternalStore } from 'react'
 
 // in memory fallback used then `localStorage` throws an error
 export const inMemoryData = new Map<string, unknown>()
@@ -84,7 +84,7 @@ function useBrowserLocalStorageState<T>(
     parse: (value: string) => unknown = parseJSON,
     stringify: (value: unknown) => string = JSON.stringify,
 ): LocalStorageState<T | undefined> {
-    const initialDefaultValue = useRef(defaultValue).current
+    const [initialDefaultValue] = useState(defaultValue)
 
     // store default value in localStorage:
     // - initial issue: https://github.com/astoilkov/use-local-storage-state/issues/26


### PR DESCRIPTION
First thanks for creating and maintaining this module! Looking at the docs:

> The default value. You can think of it as the same as `useState(defaultValue)`.

I would expect something like this to work:
```js
useLocalStorageState('mykey', { defaultValue: () => someExpensiveComputation() })
```
because that's how useState works:
```js
useState(() => someExpensiveComputation())
```

Looking at the code, it uses useRef, however [useRef doesn't support functional initialzier](https://github.com/facebook/react/issues/14490), so this PR attempts to add support for that
