### PR TITLE
move removeItem to useCallback

### DIFF
--- a/src/useLocalStorageState.ts
+++ b/src/useLocalStorageState.ts
@@ -151,6 +151,14 @@ function useLocalStorage<T>(
         [key, stringify],
     )
 
+    const removeItem = useCallback(() => {
+        goodTry(() => localStorage.removeItem(key))
+
+        inMemoryData.delete(key)
+
+        triggerCallbacks(key)
+    }, [key])
+
     // - syncs change across tabs, windows, iframes
     // - the `storage` event is called only in all tabs, windows, iframe's except the one that
     //   triggered the change
@@ -176,16 +184,10 @@ function useLocalStorage<T>(
             setState,
             {
                 isPersistent: value === defaultValue || !inMemoryData.has(key),
-                removeItem(): void {
-                    goodTry(() => localStorage.removeItem(key))
-
-                    inMemoryData.delete(key)
-
-                    triggerCallbacks(key)
-                },
+                removeItem,
             },
         ],
-        [key, setState, value, defaultValue],
+        [key, setState, value, defaultValue, removeItem],
     )
 }
 


### PR DESCRIPTION
This PR wraps `removeItem` with `useCallback` to preserve its reference in most use cases.

Currently, `removeItem` does not have a stable reference. It is being re-initialized every time a `value` is changed. This is suboptimal, because calling `removeItem` should not re-initialize itself.

An example use case would be using it in a `useEffect`:
```tsx
useEffect(() => {
  if (!user) {
    removeItem(); // causes infinite useEffect loop
  }
}, [user, removeItem]); 
```

While obviously there are ways to mitigate that, do extra checks etc., maintaining references as stable as possible should reduce possible bugs.