### PR TITLE
add defaultServerValue property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,44 @@ function useIsServerRender() {
 
 </details>
 
+<details>
+<summary>Preventing hydration errors when server default value should be different from client default value</summary>
+<p></p>
+
+Using the `defaultValue` property to differ between server and client default values will cause hydration errors. To prevent them you can use the `defaultServerValue` property.
+
+```tsx
+// this will throw hydration error
+const [state, setState] = useLocalStorageState(
+    'key',
+    {
+      defaultValue() {
+        if (isServer) {
+          return "server default value";
+        }
+        return "client default value";
+      },
+    },
+  );
+```
+
+`defaultServerValue` will overwrite `defaultValue` in the `useSyncExternalStore()` hook's `getSnapshot()` function.
+Difference is server's `getSnapshot()` will run on server and client's hydration, then `defaultValue` or local storage value will be used after that.
+
+```tsx
+const [state, setState] = useLocalStorageState(
+    'key',
+    {
+      defaultValue: "client default value",
+      defaultServerValue: "server default value",
+    },
+  );
+```
+
+> Example use cases: You want to show a modal when the user's first enter and you are persistently storing that data on `localStorage`. Using `defaultServerValue` will allow you to show the modal only on the server.
+
+</details>
+
 ## API
 
 #### `useLocalStorageState(key: string, options?: LocalStorageOptions)`
@@ -164,6 +202,14 @@ Type: `any`
 Default: `undefined`
 
 The default value. You can think of it as the same as `useState(defaultValue)`.
+
+#### `options.defaultServerValue`
+
+Type: `any`
+
+Default: `undefined`
+
+The default value for the server if it should be different from the client's default value. Server will use `defaultValue` if `defaultServerValue` is not provided.
 
 #### `options.storageSync`
 

--- a/src/useLocalStorageState.ts
+++ b/src/useLocalStorageState.ts
@@ -6,6 +6,7 @@ export const inMemoryData = new Map<string, unknown>()
 
 export type LocalStorageOptions<T> = {
     defaultValue?: T | (() => T)
+    defaultServerValue?: T | (() => T)
     storageSync?: boolean
     serializer?: {
         stringify: (value: unknown) => string
@@ -42,9 +43,11 @@ export default function useLocalStorageState<T = undefined>(
 ): LocalStorageState<T | undefined> {
     const serializer = options?.serializer
     const [defaultValue] = useState(options?.defaultValue)
+    const [defaultServerValue] = useState(options?.defaultServerValue)
     return useLocalStorage(
         key,
         defaultValue,
+        defaultServerValue,
         options?.storageSync,
         serializer?.parse,
         serializer?.stringify,
@@ -54,6 +57,7 @@ export default function useLocalStorageState<T = undefined>(
 function useLocalStorage<T>(
     key: string,
     defaultValue: T | undefined,
+    defaultServerValue: T | undefined,
     storageSync: boolean = true,
     parse: (value: string) => unknown = parseJSON,
     stringify: (value: unknown) => string = JSON.stringify,
@@ -125,7 +129,7 @@ function useLocalStorage<T>(
         },
 
         // useSyncExternalStore.getServerSnapshot
-        () => defaultValue,
+        () => defaultServerValue ?? defaultValue,
     )
     const setState = useCallback(
         (newValue: SetStateAction<T | undefined>): void => {

--- a/test/browser.test.tsx
+++ b/test/browser.test.tsx
@@ -58,10 +58,32 @@ describe('useLocalStorageState()', () => {
         expect(todos).toStrictEqual(['first', 'second'])
     })
 
-    test(`initial state is written to localStorage`, () => {
+    test('initial state is written to localStorage', () => {
         renderHook(() => useLocalStorageState('todos', { defaultValue: ['first', 'second'] }))
 
         expect(localStorage.getItem('todos')).toStrictEqual(JSON.stringify(['first', 'second']))
+    })
+
+    test('should return defaultValue instead of defaultServerValue on the browser', () => {
+        const { result } = renderHook(() =>
+            useLocalStorageState('todos', {
+                defaultValue: ['first', 'second'],
+                defaultServerValue: ['third', 'forth'],
+            }),
+        )
+
+        const [todos] = result.current
+        expect(todos).toStrictEqual(['first', 'second'])
+    })
+
+    test('defaultServerValue should not written to localStorage', () => {
+        renderHook(() =>
+            useLocalStorageState('todos', {
+                defaultServerValue: ['third', 'forth'],
+            }),
+        )
+
+        expect(localStorage.getItem('todos')).toStrictEqual(null)
     })
 
     test('updates state', () => {

--- a/test/server.test.tsx
+++ b/test/server.test.tsx
@@ -59,13 +59,38 @@ describe('useLocalStorageState()', () => {
                 }),
             )
 
-            expect(result.current[0]).toEqual(['first', 'second'])
+            const [todos] = result.current
+            expect(todos).toStrictEqual(['first', 'second'])
         })
 
         test('returns default value on the server', () => {
             const { result } = renderHookOnServer(() => useLocalStorageState('todos'))
 
-            expect(result.current[0]).toEqual(undefined)
+            const [todos] = result.current
+            expect(todos).toBe(undefined)
+        })
+
+        test('returns defaultServerValue on the server', () => {
+            const { result } = renderHookOnServer(() =>
+                useLocalStorageState('todos', {
+                    defaultServerValue: ['third', 'forth'],
+                }),
+            )
+
+            const [todos] = result.current
+            expect(todos).toStrictEqual(['third', 'forth'])
+        })
+
+        test('defaultServerValue should overwrite defaultValue on the server', () => {
+            const { result } = renderHookOnServer(() =>
+                useLocalStorageState('todos', {
+                    defaultValue: ['first', 'second'],
+                    defaultServerValue: ['third', 'forth'],
+                }),
+            )
+
+            const [todos] = result.current
+            expect(todos).toStrictEqual(['third', 'forth'])
         })
 
         test(`setValue() on server doesn't throw`, () => {


### PR DESCRIPTION
#### Reason

we have a modal to defaults to open if local storage value does not exists. If value for opened before is undefined we want to open modal. using `defaultValue` to set key to `false` causes modal to flashes on top that. we tried setting different values for client and server in `defaultValue` using it as function.

```tsx
const [state, setState] = useLocalStorageState(
    'key',
    {
      defaultValue() {
        if (isServer) {
          return "server default value";
        }
        return "client default value";
      },
    },
  );
```

code above prevents modal first opening then closing as flash but now causes hydration errors.
fix is using `getServerSnapshot` to differ client and server defaults. `getServerSnapshot` function runs during SSR and first hydration so it prevents that errors. [See docs](https://react.dev/reference/react/useSyncExternalStore#adding-support-for-server-rendering)

#### What is done

- Added field `defaultServerValue`
- Make sure that it not brokes current versions
- Added tests for client and server
- Added `readme`