### PR TITLE
fix: handle localStorage null (approach A: detect unavailability)

### DIFF
--- a/src/useLocalStorageState.ts
+++ b/src/useLocalStorageState.ts
@@ -87,7 +87,20 @@ function useLocalStorage<T>(
 
         // useSyncExternalStore.getSnapshot
         () => {
-            const string = goodTry(() => localStorage.getItem(key)) ?? null
+            const rawString = goodTry(() => localStorage.getItem(key))
+
+            // when `goodTry` returns `undefined`, it means localStorage threw an error
+            // (e.g., localStorage is `null` in Firefox when dom.storage.enabled is false).
+            // this is different from localStorage.getItem() returning `null` (key doesn't exist).
+            if (rawString === undefined && !inMemoryData.has(key)) {
+                if (defaultValue !== undefined) {
+                    inMemoryData.set(key, defaultValue)
+                }
+                storageItem.current = { string: null, parsed: defaultValue }
+                return storageItem.current.parsed
+            }
+
+            const string = rawString ?? null
 
             if (inMemoryData.has(key)) {
                 storageItem.current.parsed = inMemoryData.get(key) as T | undefined
@@ -117,7 +130,6 @@ function useLocalStorage<T>(
                 //   `localStorage.setItem()` will throw
                 // - trying to access localStorage object when cookies are disabled in Safari throws
                 //   "SecurityError: The operation is insecure."
-                // eslint-disable-next-line no-console
                 goodTry(() => {
                     const string = stringify(defaultValue)
                     localStorage.setItem(key, string)

--- a/test/browser.test.tsx
+++ b/test/browser.test.tsx
@@ -705,6 +705,111 @@ describe('useLocalStorageState()', () => {
         })
     })
 
+    describe('localStorage is null (Firefox with dom.storage.enabled: false)', () => {
+        test('returns defaultValue when localStorage is null', () => {
+            vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null as any)
+
+            const { result } = renderHook(() =>
+                useLocalStorageState('todos', { defaultValue: ['first', 'second'] }),
+            )
+
+            const [todos] = result.current
+            expect(todos).toStrictEqual(['first', 'second'])
+        })
+
+        test('isPersistent is true when value equals defaultValue and localStorage is null', () => {
+            vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null as any)
+
+            const { result } = renderHook(() =>
+                useLocalStorageState('todos', { defaultValue: ['first', 'second'] }),
+            )
+
+            const [, , { isPersistent }] = result.current
+            expect(isPersistent).toBe(true)
+        })
+
+        test('isPersistent is false when value is changed and localStorage is null', () => {
+            vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null as any)
+
+            const { result } = renderHook(() =>
+                useLocalStorageState('todos', { defaultValue: ['first', 'second'] }),
+            )
+
+            act(() => {
+                const setTodos = result.current[1]
+                setTodos(['third', 'forth'])
+            })
+
+            const [todos, , { isPersistent }] = result.current
+            expect(todos).toStrictEqual(['third', 'forth'])
+            expect(isPersistent).toBe(false)
+        })
+
+        test('setValue works when localStorage is null', () => {
+            vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null as any)
+
+            const { result } = renderHook(() =>
+                useLocalStorageState('todos', { defaultValue: ['first', 'second'] }),
+            )
+
+            act(() => {
+                const setTodos = result.current[1]
+                setTodos(['third', 'forth'])
+            })
+
+            const [todos] = result.current
+            expect(todos).toStrictEqual(['third', 'forth'])
+        })
+
+        test('setValue with callback works when localStorage is null', () => {
+            vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null as any)
+
+            const { result } = renderHook(() =>
+                useLocalStorageState('todos', { defaultValue: ['first', 'second'] }),
+            )
+
+            act(() => {
+                const setTodos = result.current[1]
+                setTodos((value) => [...value, 'third'])
+            })
+
+            const [todos] = result.current
+            expect(todos).toStrictEqual(['first', 'second', 'third'])
+        })
+
+        test('removeItem works when localStorage is null', () => {
+            vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null as any)
+
+            const { result } = renderHook(() =>
+                useLocalStorageState('todos', { defaultValue: ['first', 'second'] }),
+            )
+
+            act(() => {
+                const setTodos = result.current[1]
+                setTodos(['third', 'forth'])
+            })
+
+            act(() => {
+                const removeItem = result.current[2].removeItem
+                removeItem()
+            })
+
+            const [todos] = result.current
+            expect(todos).toStrictEqual(['first', 'second'])
+        })
+
+        test('returns undefined when no defaultValue and localStorage is null', () => {
+            vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null as any)
+
+            const { result } = renderHook(() =>
+                useLocalStorageState('todos'),
+            )
+
+            const [todos] = result.current
+            expect(todos).toBe(undefined)
+        })
+    })
+
     describe('"serializer" option', () => {
         test('can serialize Date from initial value', () => {
             const date = new Date()


### PR DESCRIPTION
## Summary

Fixes #80 — Firefox with `dom.storage.enabled: false` sets `localStorage` to `null`, causing the hook to break.

### Approach: Detect localStorage unavailability via `goodTry` return value

The key insight: `goodTry(() => localStorage.getItem(key))` returns `undefined` when localStorage throws (e.g., `localStorage` is `null` in Firefox), but returns `null` when the key doesn't exist. Previously, both cases were coerced to `null` via `?? null`, losing this distinction.

**Changes:**
- In `getSnapshot`, check if `rawString === undefined` (localStorage unavailable) before coercing to `null`
- When localStorage is unavailable and no in-memory data exists, store `defaultValue` in `inMemoryData` for proper fallback
- This automatically makes `isPersistent` correct: `true` when value equals default, `false` after `setValue`

**Why this approach:**
- Minimal code change — only the `getSnapshot` function is modified
- No type changes needed
- Leverages the existing `goodTry` semantics (returns `undefined` on error)
- The rest of the hook (setState, removeItem) already handles in-memory fallback correctly via try-catch

### Alternative approach
See PR #83 for approach B (sentinel value fix) — a different way to solve the same issue.

## Next.js test projects

To test in Firefox with `dom.storage.enabled: false` in `about:config`:

- **main branch (shows the bug):** https://localstorage-null-test-main-9slssprfd-astoilkov1s-projects.vercel.app
- **this PR (approach A fix):** https://localstorage-null-test-approach-bvxehsog0-astoilkov1s-projects.vercel.app

## Test plan
- [x] Added 7 tests simulating `localStorage` being `null` via `vi.spyOn(window, 'localStorage', 'get').mockReturnValue(null)`
- [x] Tests cover: defaultValue, isPersistent, setValue, setValue with callback, removeItem, no defaultValue