### PR TITLE
Add package bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
         "type": "git",
         "url": "git+https://github.com/astoilkov/use-local-storage-state.git"
     },
+    "bugs": {
+        "url": "https://github.com/astoilkov/use-local-storage-state/issues"
+    },
     "funding": "https://github.com/sponsors/astoilkov",
     "homepage": "https://github.com/astoilkov/use-local-storage-state",
     "author": {


### PR DESCRIPTION
## Summary
- add the standard npm `bugs.url` metadata pointing to the GitHub issue tracker
- leave runtime code, dependencies, exports, and package files unchanged

## Verification
- `node -e "const p=require('./package.json'); if(p.bugs.url!=='https://github.com/astoilkov/use-local-storage-state/issues') process.exit(1); console.log(JSON.stringify({name:p.name, bugs:p.bugs}))"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`